### PR TITLE
Stabilize snapshot toolchain baseline

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -65,6 +65,24 @@
       }
     },
     {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "647c708be89f834fa6a6d4945442793a77ddf5b6",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
+      }
+    },
+    {
       "identity" : "swift-format",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-format",


### PR DESCRIPTION
## Why
The project needs a clean baseline before deeper work on test stability, reflection extraction, and documentation rebrand. This branch captures the toolchain lockfile state so everyone resolves the same dependency graph while we continue the stabilization pass.

## What changed
- Refreshed `Package.resolved` to the current, reproducible SwiftPM dependency set.
- No source behavior changes in this PR.

## Notes for reviewers
This is intentionally small and mechanical. The next PRs will carry the actual runtime/test fixes and README repositioning work.