### PR TITLE
Establish testing baseline and hardening roadmap

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,48 @@
+# SwiftSnapshot Progressive Plan
+## Goal
+Make the project easier to trust and easier to understand.
+Do it in this order: test coverage, isolation/deprecation, docs/story.
+## Phase 1 — Testing baseline first
+1. Freeze current behavior with executable tests.
+2. Classify tests by reliability layer:
+    - deterministic core
+    - macro expansion layer
+    - performance signal
+    - manual verification
+3. Keep snapshot assertions readable and diff-friendly.
+4. Add targeted reflection edge-case tests:
+    - optionals
+    - nested generics
+    - enum payloads
+    - dictionaries with deterministic ordering
+    - collection edge-cases
+Status:
+- Added `TESTING.md` with this matrix and baseline commands.
+## Phase 2 — Isolate weak surfaces
+1. Keep reflection/built-ins as the stable default path.
+2. Treat macro expression-string rendering as experimental/opt-in only.
+3. Deprecate APIs that encourage dependence on unstable rendering internals.
+4. If needed, split reflection engine into a dedicated target boundary:
+    - `SwiftSnapshotCore` for runtime API + formatting + export flow
+    - `SwiftSnapshotReflection` for reflection details and tests
+## Phase 3 — Reflection quality pass
+1. Compare behavior with pointfreeco/swift-debug-snapshots where useful.
+2. Borrow test cases and engine ideas that improve determinism/correctness.
+3. Add regression tests before changing behavior.
+## Phase 4 — Documentation and README rewrite
+Voice:
+- certain
+- unhurried
+- direct
+- short sentences
+- no hype
+Structure:
+1. What it is
+2. Why Swift fixtures instead of JSON
+3. How it works
+4. Guarantees
+5. Limits
+6. Where it fits
+## Current blockers
+- Local SwiftPM test runtime crash (signal 11) in `swiftpm-testing-helper`.
+- This blocks complete test verification in current environment.

--- a/Package.resolved
+++ b/Package.resolved
@@ -65,6 +65,24 @@
       }
     },
     {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "647c708be89f834fa6a6d4945442793a77ddf5b6",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
+      }
+    },
+    {
       "identity" : "swift-format",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-format",

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,78 @@
+# Testing Strategy
+
+SwiftSnapshot has different reliability layers.
+They are tested differently on purpose.
+
+## 1. Deterministic core (blocking)
+
+These tests define stable behavior.
+They must pass in normal CI.
+
+- Rendering primitives and collections
+- Reflection-based struct and enum rendering
+- Deterministic ordering and identifier sanitization
+- Config, formatting profile loading, and path resolution
+- File export behavior
+
+Current suites:
+
+- `SwiftSnapshotTests/SwiftSnapshotTests.swift`
+- `SwiftSnapshotTests/IntegrationTests.swift`
+- `SwiftSnapshotTests/ReproductionTests.swift`
+- `SwiftSnapshotTests/GenericCollectionTests.swift`
+- `SwiftSnapshotTests/IntegerTypesTests.swift`
+- `SwiftSnapshotTests/GeneratedCodeValidityTests.swift`
+- `SwiftSnapshotTests/VariableNameSanitizationTests.swift`
+- `SwiftSnapshotTests/RenderOptionsTests.swift`
+- `SwiftSnapshotTests/FormattingConfigTests.swift`
+- `SwiftSnapshotTests/SwiftSnapshotConfigTests.swift`
+- `SwiftSnapshotTests/SnapshotRenderContextTests.swift`
+- `SwiftSnapshotTests/SnapshotRendererRegistryTests.swift`
+- `SwiftSnapshotTests/PathResolverTests.swift`
+- `SwiftSnapshotTests/DependencyInjectionTests.swift`
+- `SwiftSnapshotTests/SwiftSnapshotErrorTests.swift`
+- `SwiftSnapshotTests/EditorConfigIntegrationTests.swift`
+
+## 2. Macro expansion behavior (separate layer)
+
+Macro tests validate generated declarations and annotations.
+They are not the same as runtime reflection correctness.
+
+Current suites:
+
+- `SwiftSnapshotMacrosTests/SwiftSnapshotMacrosTests.swift`
+- `SwiftSnapshotMacrosTests/IntegrationTests.swift`
+
+These tests use `MacroTesting` and snapshot-style assertions similar to pointfreeco/swift-macro-testing.
+
+## 3. Performance characterization (non-blocking signal)
+
+Performance tests detect regressions.
+They should inform decisions, not hide correctness failures.
+
+Current suite:
+
+- `SwiftSnapshotTests/PerformanceTests.swift`
+
+## 4. Manual verification (not part of CI guarantees)
+
+Manual checks stay isolated.
+They are useful during development, but they do not define stability guarantees.
+
+Current file:
+
+- `SwiftSnapshotTests/ManualSanitizationVerification.swift`
+
+## Baseline commands
+
+Run runtime/core tests:
+
+```bash
+swift test --filter SwiftSnapshotTests
+```
+
+Run macro tests:
+
+```bash
+swift test --filter SwiftSnapshotMacrosTests
+```


### PR DESCRIPTION
SwiftSnapshot needs a clearer path for reliability work before broader changes. This draft locks in the first hardening step: make the testing story explicit and progressive, and document what is guaranteed vs what is exploratory.

## What changed

- Added `TESTING.md` with a layered test strategy:
  - deterministic core behavior
  - macro expansion layer
  - performance signal layer
  - manual verification layer
- Added `PLAN.md` to capture the progressive hardening sequence:
  - test baseline first
  - isolate/deprecate weak surfaces
  - reflection quality pass
  - documentation/README rewrite in a direct voice
- Updated `Package.resolved` to keep dependency resolution state in sync with the branch.

## Why this approach

The project needs stable foundations before deeper refactors. This makes review and future changes easier by defining reliability boundaries up front.

## Notes for reviewers

- This is intentionally a documentation-and-process baseline PR.
- Runtime and docs rewrites from later plan phases are not included in this draft yet.
- Local test execution in this environment hit a SwiftPM runtime crash (`swiftpm-testing-helper`, signal 11), so this branch focuses on establishing the test strategy and execution map first.