### PR TITLE
Allow swift-syntax and swift-format 603

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"603.0.0"),
-    .package(url: "https://github.com/swiftlang/swift-format", "509.0.0"..<"603.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"604.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-format", "509.0.0"..<"604.0.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.7.0"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.0"),


### PR DESCRIPTION
## Problem

The upper bound of `<603.0.0` makes swift-snapshot **unresolvable** for any package whose graph already settles on swift-syntax 603 — which current `sqlite-data` and `swift-dependencies` both pull in. There is no version of swift-snapshot such a package can depend on; resolution fails outright rather than degrading to an older pin.

Found while adding swift-snapshot to a real app that resolves swift-syntax `603.0.1`.

## Change

Two lines — both ranges widened to `<604.0.0`. Nothing else.

```diff
-.package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"603.0.0"),
-.package(url: "https://github.com/swiftlang/swift-format", "509.0.0"..<"603.0.0"),
+.package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"604.0.0"),
+.package(url: "https://github.com/swiftlang/swift-format", "509.0.0"..<"604.0.0"),
```

This only *permits* a newer pair; it drops no currently supported version.

## Verification

`swift-format` 603.0.0 exists and pairs with swift-syntax 603, so the combination resolves:

```
swift-format 603.0.0
swift-syntax 603.0.2
```

`swift build` succeeds against that pair with **no source changes** — the 602 → 603 SwiftSyntax API surface this package uses is unchanged.

## Note on the test suites

Both test bundles currently exit with `signal code 11`. I checked before opening this: they crash **identically on `main` at swift-syntax 602**, so it is pre-existing and unrelated to the version range. #49 is the fix for it. This PR deliberately does not touch it.

`Package.resolved` is left alone, so CI keeps resolving the pair it resolves today — the widening is what downstream consumers need, and it changes nothing for this repo's own builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)