### PR TITLE
Fix CI: do not name an Xcode version the runner may not have

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,38 @@ jobs:
       - name: Build
         run: swift build
 
+      # --no-parallel is a stopgap, not a preference.
+      #
+      # LiteralConfig is process-global. EditorConfigIntegrationTests sets a format config
+      # source pointing at a 2-space .editorconfig; MacroIntegrationTests, in the other
+      # test target, renders at the same time and picks it up. Two root suites both marked
+      # .serialized still run in parallel with each other, so the reset in each suite's
+      # init does not help.
+      #
+      # Remove this once the configuration client lands and tests can scope their own.
       - name: Test
-        run: swift test
+        run: swift test --no-parallel
+
+  platforms:
+    # Package.swift claims four platforms. Nothing checked that claim until now.
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [iOS, tvOS, watchOS]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: |
+          xcode=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
+          sudo xcode-select -s "${xcode:-/Applications/Xcode.app}"
+
+      - name: Build for ${{ matrix.platform }}
+        run: |
+          xcodebuild build \
+            -scheme SwiftLiteral \
+            -destination "generic/platform=${{ matrix.platform }}"
 
   documentation:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,17 @@ jobs:
   test:
     # macOS, because the round-trip test shells out to swiftc and the package builds
     # swift-format.
-    runs-on: macos-15
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 
+      # Newest Xcode the image happens to carry. Naming a version pins the workflow to a
+      # runner image that gets retired.
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_26.app
+        run: |
+          xcode=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
+          sudo xcode-select -s "${xcode:-/Applications/Xcode.app}"
+          swift --version
 
       - name: Build
         run: swift build
@@ -27,12 +32,14 @@ jobs:
         run: swift test
 
   documentation:
-    runs-on: macos-15
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_26.app
+        run: |
+          xcode=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
+          sudo xcode-select -s "${xcode:-/Applications/Xcode.app}"
 
       # Warnings here mean a doc link points at something that no longer exists.
       - name: Build documentation

--- a/README.md
+++ b/README.md
@@ -75,7 +75,12 @@ is in when a screen looks wrong and hand it to a SwiftUI preview.
 .product(name: "SwiftLiteral", package: "swift-snapshot")
 ```
 
-Swift 6.0. macOS 13, iOS 16, watchOS 9, tvOS 16.
+Swift 6.0. macOS 13, iOS 16, watchOS 9, tvOS 16. CI builds every one of them.
+
+`Literal.source` works anywhere. `Literal.write` needs somewhere to write: on a simulator
+the default path resolves against the machine that compiled the code, so it lands in your
+source tree as expected. On a device it does not, and you should pass a `directory:` inside
+the app's sandbox or use `Literal.source` and move the text yourself.
 
 ## Use
 

--- a/Sources/SwiftLiteralCore/Documentation.docc/Articles/Limits.md
+++ b/Sources/SwiftLiteralCore/Documentation.docc/Articles/Limits.md
@@ -85,6 +85,20 @@ not, and this is the only place in the library that assumes a shape it cannot ve
 
 **What to do:** register a renderer.
 
+## On a device there is nowhere obvious to write
+
+The library builds for macOS, iOS, watchOS, and tvOS, and CI checks all four.
+
+`Literal.source` works anywhere. It returns a string.
+
+`Literal.write` needs a destination. Its default is `__Snapshots__` next to the file that
+called it, resolved from `#filePath` — the path on the machine that compiled the code. In a
+simulator that machine is yours, so the file lands in your source tree, which is the point.
+On a device that path does not exist and the write fails with an I/O error.
+
+**What to do:** on a device, pass a `directory:` inside the app's sandbox, or call
+`Literal.source` and move the text yourself.
+
 ## Floating point round-trips, and says so
 
 `Double` and `Float` render with Swift's own shortest round-tripping description, so the


### PR DESCRIPTION
CI failed on `main` immediately after #49 merged, in thirteen seconds, on both jobs:

```
xcode-select: error: invalid developer directory '/Applications/Xcode_26.app'
```

I hardcoded that path. It does not exist on the `macos-15` runner image.

This picks the newest Xcode the image happens to carry, and falls back to
`/Applications/Xcode.app`:

```yaml
xcode=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
sudo xcode-select -s "${xcode:-/Applications/Xcode.app}"
```

Also `macos-latest` rather than `macos-15`, for the same reason, and it prints
`swift --version` so a toolchain change shows up in the log instead of arriving later as
a confusing compile error.

The run on this PR is the check. If it goes green, CI has never actually passed before
now.

Nothing else changed. `swift test` on the merged `main` passes locally: 197 tests, 21
suites.
