### PR TITLE
Read configuration through a dependency, so tests stop sharing it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,17 +28,8 @@ jobs:
       - name: Build
         run: swift build
 
-      # --no-parallel is a stopgap, not a preference.
-      #
-      # LiteralConfig is process-global. EditorConfigIntegrationTests sets a format config
-      # source pointing at a 2-space .editorconfig; MacroIntegrationTests, in the other
-      # test target, renders at the same time and picks it up. Two root suites both marked
-      # .serialized still run in parallel with each other, so the reset in each suite's
-      # init does not help.
-      #
-      # Remove this once the configuration client lands and tests can scope their own.
       - name: Test
-        run: swift test --no-parallel
+        run: swift test
 
   platforms:
     # Package.swift claims four platforms. Nothing checked that claim until now.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,38 @@ jobs:
       - name: Build
         run: swift build
 
+      # --no-parallel is a stopgap, not a preference.
+      #
+      # LiteralConfig is process-global. EditorConfigIntegrationTests sets a format config
+      # source pointing at a 2-space .editorconfig; MacroIntegrationTests, in the other
+      # test target, renders at the same time and picks it up. Two root suites both marked
+      # .serialized still run in parallel with each other, so the reset in each suite's
+      # init does not help.
+      #
+      # Remove this once the configuration client lands and tests can scope their own.
       - name: Test
-        run: swift test
+        run: swift test --no-parallel
+
+  platforms:
+    # Package.swift claims four platforms. Nothing checked that claim until now.
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [iOS, tvOS, watchOS]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: |
+          xcode=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
+          sudo xcode-select -s "${xcode:-/Applications/Xcode.app}"
+
+      - name: Build for ${{ matrix.platform }}
+        run: |
+          xcodebuild build \
+            -scheme SwiftLiteral \
+            -destination "generic/platform=${{ matrix.platform }}"
 
   documentation:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,17 @@ jobs:
   test:
     # macOS, because the round-trip test shells out to swiftc and the package builds
     # swift-format.
-    runs-on: macos-15
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 
+      # Newest Xcode the image happens to carry. Naming a version pins the workflow to a
+      # runner image that gets retired.
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_26.app
+        run: |
+          xcode=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
+          sudo xcode-select -s "${xcode:-/Applications/Xcode.app}"
+          swift --version
 
       - name: Build
         run: swift build
@@ -27,12 +32,14 @@ jobs:
         run: swift test
 
   documentation:
-    runs-on: macos-15
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_26.app
+        run: |
+          xcode=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
+          sudo xcode-select -s "${xcode:-/Applications/Xcode.app}"
 
       # Warnings here mean a doc link points at something that no longer exists.
       - name: Build documentation

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "beb7ed4e7075598a639aeddae698f1b03162f53dc0c06f23979a9027ef32b84f",
+  "originHash" : "c4da1068e842ddf04a4d773e82f008a4794045b7107b37bc3ec6b0f941ff9f6f",
   "pins" : [
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version" : "1.2.0"
+      }
+    },
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,15 @@
       "state" : {
         "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
         "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "72d749bf341b78851203066ab421869b783ec42a",
+        "version" : "1.1.0"
       }
     },
     {
@@ -20,12 +38,30 @@
       }
     },
     {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5fa253428866f2360c3754e88537f700ed2656b5",
+        "version" : "1.4.1"
+      }
+    },
+    {
       "identity" : "swift-custom-dump",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
         "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
         "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "swift-dependencies",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-dependencies",
+      "state" : {
+        "revision" : "bdbc1892d22359baa1c1e720cb9ca244d5208718",
+        "version" : "1.16.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.11.0"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", "1.18.0"..<"1.19.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.0"),
+    .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.10.0"),
   ],
   targets: [
     // Macro implementation (compiler plugin + public macro definitions)
@@ -44,6 +45,7 @@ let package = Package(
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftParser", package: "swift-syntax"),
         .product(name: "SwiftParserDiagnostics", package: "swift-syntax"),
+        .product(name: "DependenciesTestSupport", package: "swift-dependencies"),
       ],
       path: "Sources/SwiftLiteralReflection"
     ),
@@ -58,6 +60,7 @@ let package = Package(
         .product(name: "SwiftParser", package: "swift-syntax"),
         .product(name: "SwiftFormat", package: "swift-format"),
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
+        .product(name: "Dependencies", package: "swift-dependencies"),
       ],
       path: "Sources/SwiftLiteralCore"
     ),
@@ -77,8 +80,10 @@ let package = Package(
       name: "SwiftLiteralReflectionTests",
       dependencies: [
         "SwiftLiteralReflection",
+        .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
         .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
-      ]
+      ],
+      exclude: ["__Snapshots__"]
     ),
 
     // Core runtime tests

--- a/README.md
+++ b/README.md
@@ -75,7 +75,12 @@ is in when a screen looks wrong and hand it to a SwiftUI preview.
 .product(name: "SwiftLiteral", package: "swift-snapshot")
 ```
 
-Swift 6.0. macOS 13, iOS 16, watchOS 9, tvOS 16.
+Swift 6.0. macOS 13, iOS 16, watchOS 9, tvOS 16. CI builds every one of them.
+
+`Literal.source` works anywhere. `Literal.write` needs somewhere to write: on a simulator
+the default path resolves against the machine that compiled the code, so it lands in your
+source tree as expected. On a device it does not, and you should pass a `directory:` inside
+the app's sandbox or use `Literal.source` and move the text yourself.
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,27 @@ LiteralConfig.setRenderOptions(
 )
 ```
 
+### Configuration in tests
+
+`LiteralConfig` is process-global. That is fine for an app and wrong for a test suite:
+tests run concurrently, so one test setting a two-space `.editorconfig` changes what
+another test renders, and the failure only shows up when the timing is unlucky.
+
+So a render reads its configuration from a dependency, not from the globals. Its test value
+is the library defaults and nothing else. To render with something else, say so:
+
+```swift
+import Dependencies
+
+withDependencies {
+    $0.literalConfiguration.formatProfile = { FormatProfile(indentSize: 2) }
+} operation: {
+    let code = try Literal.source(of: value, named: "fixture")
+}
+```
+
+The override is a task local, so it applies to that test and no other.
+
 ## What it does not do
 
 **It is not a mocking library.** It gives you the data a test consumes. It does not

--- a/Sources/SwiftLiteralCore/Documentation.docc/Articles/Formatting.md
+++ b/Sources/SwiftLiteralCore/Documentation.docc/Articles/Formatting.md
@@ -57,11 +57,40 @@ Four spaces. LF. Final newline. No trailing whitespace.
 FormatProfile.default
 ```
 
+## In tests
+
+``LiteralConfig`` is process-global. In an app that is fine. In a test suite it is not:
+tests run concurrently, so one test setting a two-space `.editorconfig` changes what
+another test renders, and the failure is timing-dependent. It passes on your machine and
+fails on CI.
+
+So a render does not read the globals in tests. It reads
+``LiteralConfigurationClient``, whose test value is the library defaults and nothing else.
+Four spaces, deterministic ordering, no global root, whatever any other test is doing.
+
+To render with something else, say so:
+
+```swift
+withDependencies {
+  $0.literalConfiguration.formatProfile = { FormatProfile(indentSize: 2) }
+} operation: {
+  let code = try Literal.source(of: value, named: "fixture")
+}
+```
+
+The override lives in a task local, so it applies to that test and no other.
+
+To test the global pathway itself, opt the suite back into the live client:
+
+```swift
+@Suite(.dependency(\.literalConfiguration, .live))
+struct MyConfigTests { … }
+```
+
 ## Reset
 
 ```swift
 LiteralConfig.resetToLibraryDefaults()
 ```
 
-Configuration is global, so a test that changes it changes it for whatever runs next. Reset
-in your suite's `init`.
+For an app that configured the library at launch and wants to undo it.

--- a/Sources/SwiftLiteralCore/Documentation.docc/Articles/Limits.md
+++ b/Sources/SwiftLiteralCore/Documentation.docc/Articles/Limits.md
@@ -85,6 +85,20 @@ not, and this is the only place in the library that assumes a shape it cannot ve
 
 **What to do:** register a renderer.
 
+## On a device there is nowhere obvious to write
+
+The library builds for macOS, iOS, watchOS, and tvOS, and CI checks all four.
+
+`Literal.source` works anywhere. It returns a string.
+
+`Literal.write` needs a destination. Its default is `__Snapshots__` next to the file that
+called it, resolved from `#filePath` — the path on the machine that compiled the code. In a
+simulator that machine is yours, so the file lands in your source tree, which is the point.
+On a device that path does not exist and the write fails with an I/O error.
+
+**What to do:** on a device, pass a `directory:` inside the app's sandbox, or call
+`Literal.source` and move the text yourself.
+
 ## Floating point round-trips, and says so
 
 `Double` and `Float` render with Swift's own shortest round-tripping description, so the

--- a/Sources/SwiftLiteralCore/Literal.swift
+++ b/Sources/SwiftLiteralCore/Literal.swift
@@ -1,3 +1,4 @@
+import Dependencies
 import Foundation
 import IssueReporting
 import SwiftLiteralReflection
@@ -56,25 +57,27 @@ public enum Literal {
     header: String? = nil,
     context: String? = nil
   ) throws -> String {
+    @Dependency(\.literalConfiguration) var configuration
+
     let variableName = sanitize(name)
 
     let formatting: FormatProfile
-    if let configSource = LiteralConfig.getFormatConfigSource() {
+    if let configSource = configuration.formatConfigSource() {
       formatting = try FormatConfigLoader.loadProfile(from: configSource)
     } else {
-      formatting = LiteralConfig.formattingProfile()
+      formatting = configuration.formatProfile()
     }
 
     let expression = try ValueRenderer.render(
       value,
-      context: RenderContext(options: LiteralConfig.renderOptions())
+      context: RenderContext(options: configuration.renderOptions())
     )
 
     return CodeFormatter.formatFile(
       typeName: String(describing: T.self),
       variableName: variableName,
       expression: expression,
-      header: header ?? LiteralConfig.getGlobalHeader(),
+      header: header ?? configuration.globalHeader(),
       context: context,
       profile: formatting
     )
@@ -108,6 +111,8 @@ public enum Literal {
     filePath: StaticString = #filePath
   ) throws -> URL {
     #if DEBUG
+    @Dependency(\.literalConfiguration) var configuration
+
     let variableName = sanitize(name)
     let code = try source(of: value, named: variableName, header: header, context: context)
 
@@ -117,6 +122,7 @@ public enum Literal {
       file: file,
       outputDirectory: PathResolver.resolveOutputDirectory(
         directory: directory,
+        globalRoot: configuration.globalRoot(),
         fileID: fileID,
         filePath: filePath
       )

--- a/Sources/SwiftLiteralCore/LiteralConfigurationClient.swift
+++ b/Sources/SwiftLiteralCore/LiteralConfigurationClient.swift
@@ -1,0 +1,83 @@
+import Dependencies
+import Foundation
+import SwiftLiteralReflection
+
+/// The configuration a render reads, as a dependency.
+///
+/// ``LiteralConfig`` is process-global. That is fine for an app and wrong for a test
+/// suite: two tests running at the same time share it, so one test setting a two-space
+/// `.editorconfig` changes what another test renders. That failure is timing-dependent,
+/// which means it passes locally and fails on CI.
+///
+/// This client is the seam. In a test, scope the configuration to the test:
+///
+/// ```swift
+/// withDependencies {
+///   $0.literalConfiguration.formatProfile = { FormatProfile(indentSize: 2) }
+/// } operation: {
+///   let code = try Literal.source(of: value, named: "fixture")
+/// }
+/// ```
+///
+/// Closures rather than plain values, because the live implementation has to read the
+/// globals at the moment of the render. A stored value would be cached at first access
+/// and stop tracking ``LiteralConfig``.
+public struct LiteralConfigurationClient: Sendable {
+  public var renderOptions: @Sendable () -> RenderOptions
+  public var formatProfile: @Sendable () -> FormatProfile
+  public var formatConfigSource: @Sendable () -> FormatConfigSource?
+  public var globalRoot: @Sendable () -> URL?
+  public var globalHeader: @Sendable () -> String?
+
+  public init(
+    renderOptions: @escaping @Sendable () -> RenderOptions,
+    formatProfile: @escaping @Sendable () -> FormatProfile,
+    formatConfigSource: @escaping @Sendable () -> FormatConfigSource?,
+    globalRoot: @escaping @Sendable () -> URL?,
+    globalHeader: @escaping @Sendable () -> String?
+  ) {
+    self.renderOptions = renderOptions
+    self.formatProfile = formatProfile
+    self.formatConfigSource = formatConfigSource
+    self.globalRoot = globalRoot
+    self.globalHeader = globalHeader
+  }
+}
+
+extension LiteralConfigurationClient {
+  /// Reads ``LiteralConfig``, which is what an app configures.
+  public static let live = LiteralConfigurationClient(
+    renderOptions: { LiteralConfig.renderOptions() },
+    formatProfile: { LiteralConfig.formattingProfile() },
+    formatConfigSource: { LiteralConfig.getFormatConfigSource() },
+    globalRoot: { LiteralConfig.getGlobalRoot() },
+    globalHeader: { LiteralConfig.getGlobalHeader() }
+  )
+
+  /// Library defaults, and nothing else.
+  ///
+  /// This is the test value on purpose. A test gets four-space indentation, deterministic
+  /// ordering, and no global root, whatever any other test is doing at the same moment.
+  /// A test that wants something else says so with `withDependencies`.
+  public static let `default` = LiteralConfigurationClient(
+    renderOptions: { .default },
+    formatProfile: { .default },
+    formatConfigSource: { nil },
+    globalRoot: { nil },
+    globalHeader: { nil }
+  )
+}
+
+private enum LiteralConfigurationKey: DependencyKey {
+  static let liveValue = LiteralConfigurationClient.live
+  static let testValue = LiteralConfigurationClient.default
+  static let previewValue = LiteralConfigurationClient.live
+}
+
+extension DependencyValues {
+  /// The configuration the next render will read.
+  public var literalConfiguration: LiteralConfigurationClient {
+    get { self[LiteralConfigurationKey.self] }
+    set { self[LiteralConfigurationKey.self] = newValue }
+  }
+}

--- a/Sources/SwiftLiteralCore/PathResolver.swift
+++ b/Sources/SwiftLiteralCore/PathResolver.swift
@@ -62,6 +62,7 @@ enum PathResolver {
   /// - Returns: URL to the output directory where snapshot files should be written
   static func resolveOutputDirectory(
     directory outputBasePath: String?,
+    globalRoot: URL?,
     fileID: StaticString,
     filePath: StaticString
   ) -> URL {
@@ -70,8 +71,8 @@ enum PathResolver {
       return URL(fileURLWithPath: basePath)
     }
 
-    // 2. Global configuration
-    if let globalRoot = LiteralConfig.getGlobalRoot() {
+    // 2. Configuration, handed in by the caller rather than read from a global here.
+    if let globalRoot {
       return globalRoot
     }
 

--- a/Tests/SwiftLiteralMacrosTests/IntegrationTests.swift
+++ b/Tests/SwiftLiteralMacrosTests/IntegrationTests.swift
@@ -102,9 +102,8 @@ struct EmptyReflectionFieldsExportable: LiteralFields {
 
 extension LiteralTests {
   @Suite struct MacroIntegrationTests {
-    init() {
-      LiteralConfig.resetToLibraryDefaults()
-    }
+    // No setup. The test configuration client is already library defaults, and nothing
+    // another suite does can change that.
 
     /// Assert on what the library writes, not on an intermediate string.
     ///
@@ -268,25 +267,13 @@ extension LiteralTests {
     }
 
     @Test func nestedTypeWithRedaction() throws {
-      // This test verifies that when a type with @SwiftLiteral and @LiteralRedact
-      // is nested inside another type during export, the redaction is properly applied
-      let originalFormatConfigSource = LiteralConfig.getFormatConfigSource()
-      let originalFormatProfile = LiteralConfig.formattingProfile()
-      defer {
-        LiteralConfig.setFormatConfigSource(originalFormatConfigSource)
-        LiteralConfig.setFormattingProfile(originalFormatProfile)
-      }
-      LiteralConfig.setFormatConfigSource(nil)
-      LiteralConfig.setFormattingProfile(
-        FormatProfile(
-          indentStyle: .space,
-          indentSize: 4,
-          endOfLine: .lf,
-          insertFinalNewline: true,
-          trimTrailingWhitespace: true
-        )
-      )
-      
+      // Redaction on a type nested inside another type, through an array, through a
+      // generic.
+      //
+      // This test used to save the global format configuration, overwrite it, and put it
+      // back, because another suite could change it mid-render. That is no longer
+      // possible: the test client hands out library defaults and ignores the globals.
+
       let mockData = [
         TestKakou(toto: "hello", tata: .b),
         TestKakou(toto: "world", tata: .c),

--- a/Tests/SwiftLiteralTests/EditorConfigIntegrationTests.swift
+++ b/Tests/SwiftLiteralTests/EditorConfigIntegrationTests.swift
@@ -1,3 +1,4 @@
+import DependenciesTestSupport
 import InlineSnapshotTesting
 import Testing
 
@@ -5,7 +6,7 @@ import Testing
 
 extension LiteralTests {
   /// Comprehensive tests for EditorConfig behavior verification
-  @Suite struct EditorConfigIntegrationTests {
+  @Suite(.dependency(\.literalConfiguration, .live)) struct EditorConfigIntegrationTests {
     init() {
       // Reset configuration between tests
       LiteralConfig.resetToLibraryDefaults()

--- a/Tests/SwiftLiteralTests/FormattingConfigTests.swift
+++ b/Tests/SwiftLiteralTests/FormattingConfigTests.swift
@@ -1,3 +1,4 @@
+import DependenciesTestSupport
 import InlineSnapshotTesting
 import Testing
 
@@ -5,7 +6,7 @@ import Testing
 
 extension LiteralTests {
   /// Tests for format configuration loading from .swift-format and .editorconfig files
-  @Suite struct FormattingConfigTests {
+  @Suite(.dependency(\.literalConfiguration, .live)) struct FormattingConfigTests {
     init() {
       // Reset configuration between tests
       LiteralConfig.resetToLibraryDefaults()

--- a/Tests/SwiftLiteralTests/LiteralConfigTests.swift
+++ b/Tests/SwiftLiteralTests/LiteralConfigTests.swift
@@ -1,3 +1,4 @@
+import DependenciesTestSupport
 import Testing
 import Foundation
 
@@ -5,7 +6,7 @@ import Foundation
 
 extension LiteralTests {
   /// Tests for LiteralConfig
-  @Suite struct LiteralConfigTests {
+  @Suite(.dependency(\.literalConfiguration, .live)) struct LiteralConfigTests {
     
     init() {
       // Reset configuration between tests

--- a/Tests/SwiftLiteralTests/PathResolverTests.swift
+++ b/Tests/SwiftLiteralTests/PathResolverTests.swift
@@ -19,6 +19,7 @@ extension LiteralTests {
       let explicitPath = "/tmp/custom-snapshots"
       let result = PathResolver.resolveOutputDirectory(
         directory: explicitPath,
+        globalRoot: nil,
         fileID: #fileID,
         filePath: #filePath
       )
@@ -28,19 +29,18 @@ extension LiteralTests {
     
     /// Test that global configuration takes priority over environment and defaults
     @Test func resolveOutputDirectoryWithGlobalConfig() {
+      // The configured root arrives as an argument now, so this test no longer has to
+      // reach into process-global state and put it back afterwards.
       let globalRoot = URL(fileURLWithPath: "/tmp/global-snapshots")
-      LiteralConfig.setGlobalRoot(globalRoot)
-      
+
       let result = PathResolver.resolveOutputDirectory(
         directory: nil,
+        globalRoot: globalRoot,
         fileID: #fileID,
         filePath: #filePath
       )
-      
+
       #expect(result.path == globalRoot.path)
-      
-      // Cleanup
-      LiteralConfig.setGlobalRoot(nil)
     }
     
     /// Test that environment variable is used when no explicit path or global config
@@ -55,6 +55,7 @@ extension LiteralTests {
       
       let result = PathResolver.resolveOutputDirectory(
         directory: nil,
+        globalRoot: nil,
         fileID: #fileID,
         filePath: #filePath
       )
@@ -71,6 +72,7 @@ extension LiteralTests {
       
       let result = PathResolver.resolveOutputDirectory(
         directory: nil,
+        globalRoot: nil,
         fileID: #fileID,
         filePath: testFilePath
       )
@@ -203,34 +205,33 @@ extension LiteralTests {
       let globalPath = URL(fileURLWithPath: "/tmp/global")
       let envPath = "/tmp/env"
       
-      // Set up all levels
-      LiteralConfig.setGlobalRoot(globalPath)
+      // The environment variable is still process-wide, so it still needs putting back.
+      // The configured root does not, which is the whole point of the change.
       setenv("SWIFT_SNAPSHOT_ROOT", envPath, 1)
-      defer {
-        LiteralConfig.setGlobalRoot(nil)
-        unsetenv("SWIFT_SNAPSHOT_ROOT")
-      }
-      
+      defer { unsetenv("SWIFT_SNAPSHOT_ROOT") }
+
       // Explicit should win
       let result1 = PathResolver.resolveOutputDirectory(
         directory: explicitPath,
+        globalRoot: globalPath,
         fileID: #fileID,
         filePath: #filePath
       )
       #expect(result1.path == explicitPath)
-      
-      // Global should win over env
+
+      // Configured root should win over env
       let result2 = PathResolver.resolveOutputDirectory(
         directory: nil,
+        globalRoot: globalPath,
         fileID: #fileID,
         filePath: #filePath
       )
       #expect(result2.path == globalPath.path)
-      
+
       // Env should win over default
-      LiteralConfig.setGlobalRoot(nil)
       let result3 = PathResolver.resolveOutputDirectory(
         directory: nil,
+        globalRoot: nil,
         fileID: #fileID,
         filePath: #filePath
       )

--- a/Tests/SwiftLiteralTests/SwiftLiteralTests.swift
+++ b/Tests/SwiftLiteralTests/SwiftLiteralTests.swift
@@ -1,10 +1,11 @@
+import DependenciesTestSupport
 import InlineSnapshotTesting
 import Testing
 
 @testable import SwiftLiteralCore
 
 extension LiteralTests {
-  @Suite struct SwiftLiteralTests {
+  @Suite(.dependency(\.literalConfiguration, .live)) struct SwiftLiteralTests {
     init() {
       // Reset configuration between tests
       LiteralConfig.resetToLibraryDefaults()


### PR DESCRIPTION
**Stacked on #51.** Merge that first; this branch contains its commits.

## Why

CI caught the real version of the singleton problem on its first honest run:

```
−    static let testSecret: TestSecret = TestSecret(id: "secret123", apiKey: "REDACTED")
+  static let testSecret: TestSecret = TestSecret(id: "secret123", apiKey: "REDACTED")
```

Two-space indent where four was expected. `EditorConfigIntegrationTests` sets a format
config source pointing at a two-space `.editorconfig`; `MacroIntegrationTests`, in the
other test target, renders at the same moment and reads it. Two root suites both marked
`.serialized` still run in parallel with each other, so the reset in each suite's `init`
does not help.

The suite passed five times in a row locally and failed the first time it ran on someone
else's machine. That is what a shared singleton buys.

## What

`LiteralConfigurationClient` — five `@Sendable` closures, the shape the house rules ask
for.

- `liveValue` reads `LiteralConfig`, which is what an app configures.
- `testValue` returns library defaults and nothing else.

Closures rather than stored values, because the live implementation has to read the
globals at the moment of the render. A stored value would be cached at first access and
stop tracking `LiteralConfig`.

`Literal.source` and `Literal.write` read the client. `PathResolver.resolveOutputDirectory`
takes the configured root as an argument rather than reaching for the global itself.

Four suites exist to exercise the global pathway, so they opt back in:

```swift
@Suite(.dependency(\.literalConfiguration, .live))
```

Everything else gets defaults and cannot be affected by them.

## What got smaller

`nestedTypeWithRedaction` was saving the global format configuration, overwriting it, and
restoring it in a `defer`. That is a workaround for exactly this race, written before
anyone had named it. Gone.

`MacroIntegrationTests` no longer needs `resetToLibraryDefaults()` in its `init`.
`PathResolverTests` no longer mutates the process to test precedence.

`--no-parallel` comes back out of CI.

## Two unrelated one-liners the clean rebuild surfaced

- `SwiftLiteralReflectionTests` imports `SwiftSyntaxBuilder` without declaring it. It only
  linked by luck; under Xcode 27's build system it does not.
- The recorded golden file needed excluding from the target.

## Note for anyone building locally

Adding swift-dependencies means a bare `swift build` under a standalone swiftly toolchain
fails with `external macro implementation type 'SwiftUIMacros.EntryMacro' could not be
found`, from swift-dependencies' `PreviewTrait`. Use `xcrun swift build` / `xcrun swift
test`. CI is unaffected: after `xcode-select`, `swift` is Xcode's.

## Still a singleton

`ValueRendererRegistry.shared`. Next PR moves the renderers into `RenderContext` as a
value, which removes the last one and makes `removeAll()` unnecessary.

`swift test`: 197 tests, all passing.
