### PR TITLE
Say where fixtures are meant to be generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,30 @@ is in when a screen looks wrong and hand it to a SwiftUI preview.
 
 Swift 6.0. macOS 13, iOS 16, watchOS 9, tvOS 16. CI builds every one of them.
 
-`Literal.source` works anywhere. `Literal.write` needs somewhere to write: on a simulator
-the default path resolves against the machine that compiled the code, so it lands in your
-source tree as expected. On a device it does not, and you should pass a `directory:` inside
-the app's sandbox or use `Literal.source` and move the text yourself.
+**Generate on macOS or in the simulator.** That is the design. The tool writes a file into
+your source tree so you can commit it, and the simulator and your Mac are where your source
+tree is. A device build links fine, but the default output path comes from `#filePath` —
+the compiling machine's path — which does not exist on a phone.
+
+<details>
+<summary>If Xcode says <code>Unable to resolve module dependency: 'SwiftSyntax'</code></summary>
+
+That is Xcode's module scanner failing on modules it has already built, not a platform
+problem. It shows up on packages that have both a macro plugin and a library on
+swift-syntax, which is this package's shape.
+
+Clear the caches and rebuild:
+
+```bash
+rm -rf ~/Library/Caches/org.swift.swiftpm ~/Library/org.swift.swiftpm
+rm -rf ~/Library/Developer/Xcode/DerivedData/<YourProject>-*
+```
+
+SwiftPM keeps prebuilt swift-syntax artifacts in that first directory. A partial one
+produces exactly this error. Check `xcode-select -p` points at an Xcode and not a
+standalone toolchain while you are there.
+
+</details>
 
 ## Use
 

--- a/Sources/SwiftLiteralCore/Documentation.docc/Articles/Limits.md
+++ b/Sources/SwiftLiteralCore/Documentation.docc/Articles/Limits.md
@@ -85,19 +85,20 @@ not, and this is the only place in the library that assumes a shape it cannot ve
 
 **What to do:** register a renderer.
 
-## On a device there is nowhere obvious to write
+## Generate on macOS or in the simulator
 
-The library builds for macOS, iOS, watchOS, and tvOS, and CI checks all four.
+That is the design, not a workaround. The tool writes a file into your source tree so you
+can commit it. Both of those need the source tree, and the simulator and your Mac are where
+it is.
 
-`Literal.source` works anywhere. It returns a string.
+The library builds for macOS, iOS, watchOS, and tvOS, and CI checks all four, so nothing
+stops you linking it in a device build. But `Literal.write` defaults to `__Snapshots__`
+next to the file that called it, resolved from `#filePath` — the path on the machine that
+compiled the code. In the simulator that machine is yours and the file lands where you
+want it. On a device that path does not exist, and even if you point it somewhere inside
+the app container the result is a file on a phone, which is not where fixtures live.
 
-`Literal.write` needs a destination. Its default is `__Snapshots__` next to the file that
-called it, resolved from `#filePath` — the path on the machine that compiled the code. In a
-simulator that machine is yours, so the file lands in your source tree, which is the point.
-On a device that path does not exist and the write fails with an I/O error.
-
-**What to do:** on a device, pass a `directory:` inside the app's sandbox, or call
-`Literal.source` and move the text yourself.
+`Literal.source` returns a string and works anywhere, if you have somewhere to send it.
 
 ## Floating point round-trips, and says so
 


### PR DESCRIPTION
Two doc changes, both from the iOS thread.

## Where fixtures are meant to be generated

macOS or the simulator. That is the design, not a workaround: the tool writes a file into
your source tree so you can commit it, and those are the two places your source tree
exists.

The docs previously treated the device case as a configuration problem and offered
`directory:` inside the app container as a fix. That is not a fix. It is a file on a phone.

## Troubleshooting `Unable to resolve module dependency: 'SwiftSyntax'`

Someone hit this and reasonably read it as swift-format not supporting iOS. It is not that.
It is Xcode's module scanner failing on modules it has already built, on packages that have
both a macro plugin and a library on swift-syntax — which is this package's shape.

The README now says to clear `~/Library/Caches/org.swift.swiftpm`, where SwiftPM keeps
prebuilt swift-syntax artifacts, and to check `xcode-select -p`.

## Evidence

Same toolchain as the reporter — Xcode 27.0 beta `27A5237l`, Swift 6.4
`swiftlang-6.4.0.30.4`, `/Applications/Xcode-beta.app`, macOS 26.5.2 — so the "yours must
be a release Xcode" theory is out.

| Build | Result |
|---|---|
| Their 12-line macro-plugin + library repro, `platform=iOS Simulator,name=iPhone 17 Pro`, isolated DerivedData and `-clonedSourcePackagesDirPath` | **BUILD SUCCEEDED** |
| `0.3.1`, same destination, isolated caches | **BUILD SUCCEEDED** |
| A consumer package with an iOS target on `0.3.0`, simulator and device | **BUILD SUCCEEDED** |
| `0.2.1`, simulator | **BUILD SUCCEEDED** |

Same shape, same Xcode build, opposite result. The difference is machine-local.

One more datum: the bare repro resolved swift-syntax **603.0.2**, while this package
resolves **602.0.0** — swift-format 602 is the newest published and it holds swift-syntax
back. So the `..<604` range from #50 has no effect today, and no consumer is getting an
untested swift-syntax.

`swift test` on this branch: 197 passing. Docs build clean with warnings as errors.
